### PR TITLE
Reduce minified size with some small tweaks

### DIFF
--- a/src/first-input-delay.js
+++ b/src/first-input-delay.js
@@ -13,7 +13,7 @@
  limitations under the License.
 */
 
-(function() {
+(function(addEventListener, removeEventListener) {
   var firstInputEvent;
   var firstInputDelay;
   var firstInputTimeStamp;
@@ -21,6 +21,9 @@
   var callbacks = [];
   var listenerOpts = {passive: true, capture: true};
   var startTimeStamp = new Date;
+
+  var pointerup = 'pointerup';
+  var pointercancel = 'pointercancel';
 
   /**
    * Accepts a callback to be invoked once the first input delay and event
@@ -102,12 +105,12 @@
      * Removes added pointer event listeners.
      */
     function removePointerEventListeners() {
-      removeEventListener('pointerup', onPointerUp, listenerOpts);
-      removeEventListener('pointercancel', onPointerCancel, listenerOpts);
+      removeEventListener(pointerup, onPointerUp, listenerOpts);
+      removeEventListener(pointercancel, onPointerCancel, listenerOpts);
     }
 
-    addEventListener('pointerup', onPointerUp, listenerOpts);
-    addEventListener('pointercancel', onPointerCancel, listenerOpts);
+    addEventListener(pointerup, onPointerUp, listenerOpts);
+    addEventListener(pointercancel, onPointerCancel, listenerOpts);
   }
 
   /**
@@ -135,10 +138,9 @@
 
       if (evt.type == 'pointerdown') {
         onPointerDown(delay, evt);
-        return;
+      } else {
+        recordFirstInputDelay(delay, evt);
       }
-
-      recordFirstInputDelay(delay, evt);
     }
   }
 
@@ -167,4 +169,4 @@
   // Don't override the perfMetrics namespace if it already exists.
   self['perfMetrics'] = self['perfMetrics'] || {};
   self['perfMetrics']['onFirstInputDelay'] = onFirstInputDelay;
-})();
+})(addEventListener, removeEventListener);


### PR DESCRIPTION
This patch:
- Creates local aliases for global functions. These can have their names shortened by the minifier.
- Assigns some strings to variables. These, also, can be shortened.
- Replaces a short circuit return with an else block. This if/else can be replaced with a ternary by the minifier.

I'm not sure how the minified source that is checked in was generated. I tested these changes using `uglify-js@3.4.9`. This tool produced slightly larger baseline source than is checked in, at 787 bytes (without the preamble comment). This patch reduces that to 696 bytes, an ~11% reduction.